### PR TITLE
README: Update supported hal versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ This crate is intended to track `1.0.0-alpha` versions, and update to `1.0.0` on
 
 Each release of `embedded-hal-compat` supports one(ish) pair of e-h releases, because of changes to the `1.0.0-alpha`, use:
 
+- `embedded-hal-compat = "0.7.0"` for `=1.0.0-alpha.8` and `^0.2.4`
 - `embedded-hal-compat = "0.6.0"` for `=1.0.0-alpha.7` and `^0.2.4`
 - `embedded-hal-compat = "0.5.0"` for `=1.0.0-alpha.6` and `^0.2.4`
 - `embedded-hal-compat = "0.4.0"` for `=1.0.0-alpha.5` and `^0.2.4`


### PR DESCRIPTION
Just noticed that the new release doesn't mention in the `README` that it supports e-h alpha.8.

I'm actually not sure whether e-h 0.2.6 -> 0.2.7 changed the SPI traits/interfaces, but looking through the changes in #10 I don't think so.