### PR TITLE
Adapt to e-h 1.0.0-alpha.10

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ license = "MIT"
 [dependencies]
 
 defmt = { version = "0.3.0", optional = true }
+nb = "1.1"
 
 [dependencies.eh0_2]
 package = "embedded-hal"
@@ -22,4 +23,4 @@ features = [ "unproven" ]
 
 [dependencies.eh1_0]
 package = "embedded-hal"
-version = "=1.0.0-alpha.8"
+version = "=1.0.0-alpha.10"

--- a/README.md
+++ b/README.md
@@ -67,4 +67,3 @@ warning: unused import: `embedded_hal::blocking::delay::DelayMs`
 Suggesting you're missing an import that's obviously there, because you have the `0.2.x` imports not the `1.0.0-alpha.x` imports, and the method is called `try_delay_ms` in the updated HAL (a fairly common renaming).
 
 You can fix this by importing the correct trait with something like: `use embedded_hal_compat::eh1_0::blocking::delay::{DelayMs as _};` (this must be renamed with `as` / you can't use the prelude because the names overlap), and by swapping the method to use the correct `try_` name.
-

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,7 +29,7 @@
 //! // Apply forward compatibility wrapper
 //! let mut new = old.forward();
 //! // Access via e-h v1.x.x methods
-//! let _ = eh1_0::digital::blocking::OutputPin::set_high(&mut new);
+//! let _ = eh1_0::digital::OutputPin::set_high(&mut new);
 //!```
 //!
 //!
@@ -46,7 +46,7 @@
 //! // Create e-h v1.x.x based type (mock)
 //! let mut new = OutputPin1_0;
 //! // Access via e-h v1.x.x methods
-//! let _ = eh1_0::digital::blocking::OutputPin::set_high(&mut new);
+//! let _ = eh1_0::digital::OutputPin::set_high(&mut new);
 //!
 //! // Apply backwards compatibility wrapper
 //! let mut old = new.reverse();
@@ -115,7 +115,7 @@ pub mod mock {
         type Error = Infallible;
     }
 
-    impl eh1_0::digital::blocking::OutputPin for OutputPin1_0 {
+    impl eh1_0::digital::OutputPin for OutputPin1_0 {
         /// Set the output as high
         fn set_high(&mut self) -> Result<(), Self::Error> {
             Ok(())

--- a/src/reverse.rs
+++ b/src/reverse.rs
@@ -56,7 +56,7 @@ mod digital {
 
     impl<T, E> eh0_2::digital::v2::InputPin for Reverse<T>
     where
-        T: eh1_0::digital::blocking::InputPin<Error = E>,
+        T: eh1_0::digital::InputPin<Error = E>,
         E: Debug,
     {
         type Error = E;
@@ -74,7 +74,7 @@ mod digital {
 
     impl<T, E> eh0_2::digital::v2::OutputPin for Reverse<T>
     where
-        T: eh1_0::digital::blocking::OutputPin<Error = E>,
+        T: eh1_0::digital::OutputPin<Error = E>,
         E: Debug,
     {
         type Error = E;
@@ -93,45 +93,41 @@ mod digital {
 
 /// Delays (blocking)
 mod delay {
-    use super::{Debug, Reverse};
+    use super::Reverse;
 
-    impl<T, E> eh0_2::blocking::delay::DelayMs<u32> for Reverse<T>
+    impl<T> eh0_2::blocking::delay::DelayMs<u32> for Reverse<T>
     where
-        T: eh1_0::delay::blocking::DelayUs<Error = E>,
-        E: Debug,
+        T: eh1_0::delay::DelayUs,
     {
         fn delay_ms(&mut self, ms: u32) {
-            self.inner.delay_us(ms * 1000).unwrap();
+            self.inner.delay_us(ms * 1000)
         }
     }
 
-    impl<T, E> eh0_2::blocking::delay::DelayMs<u16> for Reverse<T>
+    impl<T> eh0_2::blocking::delay::DelayMs<u16> for Reverse<T>
     where
-        T: eh1_0::delay::blocking::DelayUs<Error = E>,
-        E: Debug,
+        T: eh1_0::delay::DelayUs,
     {
         fn delay_ms(&mut self, ms: u16) {
-            self.inner.delay_us(ms as u32 * 1000).unwrap();
+            self.inner.delay_us(ms as u32 * 1000)
         }
     }
 
-    impl<T, E> eh0_2::blocking::delay::DelayUs<u32> for Reverse<T>
+    impl<T> eh0_2::blocking::delay::DelayUs<u32> for Reverse<T>
     where
-        T: eh1_0::delay::blocking::DelayUs<Error = E>,
-        E: Debug,
+        T: eh1_0::delay::DelayUs,
     {
         fn delay_us(&mut self, us: u32) {
-            self.inner.delay_us(us).unwrap();
+            self.inner.delay_us(us)
         }
     }
 
-    impl<T, E> eh0_2::blocking::delay::DelayUs<u16> for Reverse<T>
+    impl<T> eh0_2::blocking::delay::DelayUs<u16> for Reverse<T>
     where
-        T: eh1_0::delay::blocking::DelayUs<Error = E>,
-        E: Debug,
+        T: eh1_0::delay::DelayUs,
     {
         fn delay_us(&mut self, us: u16) {
-            self.inner.delay_us(us as u32).unwrap();
+            self.inner.delay_us(us as u32)
         }
     }
 }
@@ -142,7 +138,7 @@ mod spi {
 
     impl<T, E> eh0_2::blocking::spi::Write<u8> for Reverse<T>
     where
-        T: eh1_0::spi::blocking::SpiBusWrite<u8, Error = E>,
+        T: eh1_0::spi::SpiBusWrite<u8, Error = E>,
         E: Debug,
     {
         type Error = E;
@@ -154,7 +150,7 @@ mod spi {
 
     impl<T, E> eh0_2::blocking::spi::Transfer<u8> for Reverse<T>
     where
-        T: eh1_0::spi::blocking::SpiBus<u8, Error = E>,
+        T: eh1_0::spi::SpiBus<u8, Error = E>,
         E: Debug,
     {
         type Error = E;
@@ -167,7 +163,7 @@ mod spi {
 
     impl<T, E> eh0_2::blocking::spi::WriteIter<u8> for Reverse<T>
     where
-        T: eh1_0::spi::blocking::SpiBusWrite<u8, Error = E>,
+        T: eh1_0::spi::SpiBusWrite<u8, Error = E>,
         E: Debug,
     {
         type Error = E;
@@ -191,7 +187,7 @@ mod i2c {
 
     impl<T, E> eh0_2::blocking::i2c::Read for Reverse<T>
     where
-        T: eh1_0::i2c::blocking::I2c<SevenBitAddress, Error = E>,
+        T: eh1_0::i2c::I2c<SevenBitAddress, Error = E>,
         E: Debug,
     {
         type Error = E;
@@ -203,7 +199,7 @@ mod i2c {
 
     impl<T, E> eh0_2::blocking::i2c::Write for Reverse<T>
     where
-        T: eh1_0::i2c::blocking::I2c<SevenBitAddress, Error = E>,
+        T: eh1_0::i2c::I2c<SevenBitAddress, Error = E>,
         E: Debug,
     {
         type Error = E;
@@ -213,24 +209,9 @@ mod i2c {
         }
     }
 
-    impl<T, E> eh0_2::blocking::i2c::WriteIter for Reverse<T>
-    where
-        T: eh1_0::i2c::blocking::I2c<SevenBitAddress, Error = E>,
-        E: Debug,
-    {
-        type Error = E;
-
-        fn write<B>(&mut self, address: SevenBitAddress, words: B) -> Result<(), Self::Error>
-        where
-            B: IntoIterator<Item = u8>,
-        {
-            self.inner.write_iter(address, words)
-        }
-    }
-
     impl<T, E> eh0_2::blocking::i2c::WriteRead for Reverse<T>
     where
-        T: eh1_0::i2c::blocking::I2c<SevenBitAddress, Error = E>,
+        T: eh1_0::i2c::I2c<SevenBitAddress, Error = E>,
         E: Debug,
     {
         type Error = E;
@@ -244,26 +225,6 @@ mod i2c {
             self.inner.write_read(address, bytes, buffer)
         }
     }
-
-    impl<T, E> eh0_2::blocking::i2c::WriteIterRead for Reverse<T>
-    where
-        T: eh1_0::i2c::blocking::I2c<SevenBitAddress, Error = E>,
-        E: Debug,
-    {
-        type Error = E;
-
-        fn write_iter_read<B>(
-            &mut self,
-            address: SevenBitAddress,
-            bytes: B,
-            buffer: &mut [u8],
-        ) -> Result<(), Self::Error>
-        where
-            B: IntoIterator<Item = u8>,
-        {
-            self.inner.write_iter_read(address, bytes, buffer)
-        }
-    }
 }
 
 /// Serial (UART etc.)
@@ -272,7 +233,7 @@ mod serial {
 
     impl<T, E> eh0_2::blocking::serial::Write<u8> for Reverse<T>
     where
-        T: eh1_0::serial::blocking::Write<u8, Error = E>,
+        T: eh1_0::serial::Write<u8, Error = E>,
         E: Debug,
     {
         type Error = E;


### PR DESCRIPTION
I had to remove the e-h 0.2 implementations for the `i2c::WriteIter` and `i2c::WriteIterRead` traits, as we have no way of collecting outputs into a buffer.
Let me know if you would prefer to keep a best-effort implementation using a fixed size array (or configurable through a const parameter) or so.
Since the reason we removed them was that nobody was using them, this seems fair to me.
It should be noted that alpha.9 has been skipped. You may want to bump the version by 2?

Fixes #15