### PR TITLE
Fix SPI error, add unit tests + some missing implementations, and more

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,69 +1,71 @@
 name: tests
 on: [push, pull_request]
 
+env:
+  RUSTFLAGS: '--deny warnings'
+
 jobs:
   clippy:
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout sources
-      uses: actions/checkout@v2
-    - name: Install Rust (stable)
-      uses: actions-rs/toolchain@v1
-      with:
-        toolchain: stable
-        components: clippy
-        override: true
-    - name: Clippy
-      uses: actions-rs/cargo@v1
-      with:
-        command: clippy
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: 1.70.0
+          targets: x86_64-unknown-linux-gnu
+          components: clippy
+
+      - run: cargo clippy --all-targets
 
   format:
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout sources
-      uses: actions/checkout@v2
-    - name: Install Rust (stable)
-      uses: actions-rs/toolchain@v1
-      with:
-        toolchain: stable
-        components: rustfmt
-        override: true
-    - name: Check Format
-      uses: actions-rs/cargo@v1
-      with:
-        command: fmt
-        args: --all -- --check
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: x86_64-unknown-linux-gnu
+          components: rustfmt
 
-  build-armv6m:
+      - run: cargo fmt --all -- --check
+
+  build:
+    name: Build
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        rust: [stable, beta, 1.60.0]
+        TARGET:
+          - x86_64-unknown-linux-gnu
+          - x86_64-unknown-linux-musl
+          - arm-unknown-linux-gnueabi # Raspberry Pi 1
+          - armv7-unknown-linux-gnueabihf # Raspberry Pi 2, 3, etc
+          # Bare metal
+          - thumbv6m-none-eabi
+          - thumbv7em-none-eabi
+          - thumbv7em-none-eabihf
+          - thumbv7m-none-eabi
+
     steps:
-    - name: Checkout sources
-      uses: actions/checkout@v2
-    - name: Install Rust (stable)
-      uses: actions-rs/toolchain@v1
-      with:
-        profile: minimal
-        toolchain: stable
-        override: true
-        target: thumbv6m-none-eabi
-    - name: Build
-      run: |
-        set -ex
-        cargo build
-        
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ matrix.rust }}
+          targets: ${{ matrix.TARGET }}
+
+      - run: cargo build --target=${{ matrix.TARGET }}
+
   test:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        rust: [stable, beta]
+        TARGET: [x86_64-unknown-linux-gnu, x86_64-unknown-linux-musl]
+
     steps:
-    - name: Checkout sources
-      uses: actions/checkout@v2
-    - name: Install Rust (stable)
-      uses: actions-rs/toolchain@v1
-      with:
-        profile: minimal
-        toolchain: stable
-        override: true
-    - name: Test
-      run: |
-        set -ex
-        cargo test
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ matrix.rust }}
+          targets: ${{ matrix.TARGET }}
+
+      - run: cargo test --target=${{ matrix.TARGET }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Serial non-blocking `Write` trait implementation for reverse compatibility.
 - Unit tests.
 
+### Removed
+- `mock` module, which contained only mock implementations for the documentation.
+
 
 ## [0.10.0] - 2023-06-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,26 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
+and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Fixed
+- Error forwarding for SPI
+
+### Added
+- SPI `FullDuplex` trait implementation for reverse compatibility.
+- Serial non-blocking `Write` trait implementation for reverse compatibility.
+- Unit tests.
+
+
+## [0.10.0] - 2023-06-25
+
+### Changed
+- Adapted to `embedded-hal` version `1.0.0-alpha.10`
+
+
+[Unreleased]: https://github.com/ryankurte/embedded-hal-compat/compare/v0.10.0...HEAD
+[0.10.0]: https://github.com/ryankurte/embedded-hal-compat/releases/tag/v0.10.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,15 +4,11 @@ description = "Compatibility layer for interoperability between different embedd
 repository = "https://github.com/ryankurte/embedded-hal-compat"
 keywords = [ "embedded", "embedded-hal", "no-std", "compat", "compatibility" ]
 version = "0.10.0"
-authors = ["ryan <ryan@kurte.nz>"]
+authors = ["Ryan Kurte <ryan@kurte.nz>", "Diego Barrios Romero <eldruin@gmail.com>"]
 edition = "2018"
 license = "MIT"
 
-[features]
-
-
 [dependencies]
-
 defmt = { version = "0.3.0", optional = true }
 nb = "1.1"
 

--- a/LICENSE-MIT
+++ b/LICENSE-MIT
@@ -1,0 +1,20 @@
+Copyright (C) 2021 Ryan Kurte
+Copyright (C) 2023 Diego Barrios Romero
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/src/forward.rs
+++ b/src/forward.rs
@@ -266,9 +266,7 @@ mod i2c {
                 eh1_0::i2c::Operation::Read(ref mut buff) => {
                     eh0_2::blocking::i2c::Operation::Read(buff)
                 }
-                eh1_0::i2c::Operation::Write(buff) => {
-                    eh0_2::blocking::i2c::Operation::Write(buff)
-                }
+                eh1_0::i2c::Operation::Write(buff) => eh0_2::blocking::i2c::Operation::Write(buff),
             });
 
             self.inner.exec_iter(address, ops).map_err(ForwardError)

--- a/src/forward.rs
+++ b/src/forward.rs
@@ -123,7 +123,6 @@ mod delay {
 /// SPI (blocking)
 mod spi {
     use super::{Forward, ForwardError};
-    use nb;
 
     impl<E: core::fmt::Debug> eh1_0::spi::Error for ForwardError<E> {
         fn kind(&self) -> eh1_0::spi::ErrorKind {
@@ -258,16 +257,16 @@ mod i2c {
                 .map_err(ForwardError)
         }
 
-        fn transaction<'a>(
+        fn transaction(
             &mut self,
             address: SevenBitAddress,
-            operations: &mut [eh1_0::i2c::Operation<'a>],
+            operations: &mut [eh1_0::i2c::Operation],
         ) -> Result<(), Self::Error> {
             let ops = operations.iter_mut().map(|op| match op {
                 eh1_0::i2c::Operation::Read(ref mut buff) => {
-                    eh0_2::blocking::i2c::Operation::Read(*buff)
+                    eh0_2::blocking::i2c::Operation::Read(buff)
                 }
-                eh1_0::i2c::Operation::Write(ref buff) => {
+                eh1_0::i2c::Operation::Write(buff) => {
                     eh0_2::blocking::i2c::Operation::Write(buff)
                 }
             });

--- a/src/forward.rs
+++ b/src/forward.rs
@@ -131,6 +131,12 @@ mod spi {
         }
     }
 
+    impl<E> From<ForwardError<nb::Error<E>>> for ForwardError<E> {
+        fn from(value: ForwardError<nb::Error<E>>) -> Self {
+            value.into()
+        }
+    }
+
     impl<T, E> eh1_0::spi::ErrorType for Forward<T>
     where
         T: eh0_2::blocking::spi::Write<u8, Error = E>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,7 +18,32 @@
 //! `v1.0.x` types.
 //!
 //!```
-//! # use embedded_hal_compat::mock::OutputPin0_2;
+//! # use core::convert::Infallible;
+//! # pub struct OutputPin0_2;
+//! #
+//! # impl eh1_0::digital::ErrorType for OutputPin0_2 {
+//! #     type Error = Infallible;
+//! # }
+//! #
+//! # impl eh0_2::digital::v2::OutputPin for OutputPin0_2 {
+//! #     type Error = Infallible;
+//! #     fn set_high(&mut self) -> Result<(), Self::Error> {
+//! #         Ok(())
+//! #     }
+//! #     fn set_low(&mut self) -> Result<(), Self::Error> {
+//! #         Ok(())
+//! #     }
+//! # }
+//! #
+//! # impl eh0_2::digital::v2::InputPin for OutputPin0_2 {
+//! #     type Error = Infallible;
+//! #     fn is_high(&self) -> Result<bool, Self::Error> {
+//! #         Ok(true)
+//! #     }
+//! #     fn is_low(&self) -> Result<bool, Self::Error> {
+//! #         Ok(false)
+//! #     }
+//! # }
 //! use embedded_hal_compat::ForwardCompat;
 //!
 //! // Create e-h v0.2.x based type (mock)
@@ -40,7 +65,24 @@
 //! `v0.2.x` types.
 //!
 //!```
-//! # use embedded_hal_compat::mock::OutputPin1_0;
+//! # use core::convert::Infallible;
+//! # pub struct OutputPin1_0;
+//! #
+//! # impl eh1_0::digital::ErrorType for OutputPin1_0 {
+//! #     type Error = Infallible;
+//! # }
+//! #
+//! # impl eh1_0::digital::OutputPin for OutputPin1_0 {
+//! #     /// Set the output as high
+//! #     fn set_high(&mut self) -> Result<(), Self::Error> {
+//! #         Ok(())
+//! #     }
+//! #
+//! #     /// Set the output as low
+//! #     fn set_low(&mut self) -> Result<(), Self::Error> {
+//! #         Ok(())
+//! #     }
+//! # }
 //! use embedded_hal_compat::ReverseCompat;
 //!
 //! // Create e-h v1.x.x based type (mock)
@@ -70,60 +112,3 @@ pub use forward::{Forward, ForwardCompat};
 
 // Reverse compatibility wrapper trait, access using `.reverse()`
 pub use reverse::{Reverse, ReverseCompat};
-
-/// Mock types for documentation, please ignore
-pub mod mock {
-    use core::convert::Infallible;
-
-    pub struct OutputPin0_2;
-
-    impl eh1_0::digital::ErrorType for OutputPin0_2 {
-        type Error = Infallible;
-    }
-
-    impl eh0_2::digital::v2::OutputPin for OutputPin0_2 {
-        type Error = Infallible;
-
-        /// Set the output as high
-        fn set_high(&mut self) -> Result<(), Self::Error> {
-            Ok(())
-        }
-
-        /// Set the output as low
-        fn set_low(&mut self) -> Result<(), Self::Error> {
-            Ok(())
-        }
-    }
-
-    impl eh0_2::digital::v2::InputPin for OutputPin0_2 {
-        type Error = Infallible;
-
-        /// Set the output as high
-        fn is_high(&self) -> Result<bool, Self::Error> {
-            Ok(true)
-        }
-
-        /// Set the output as low
-        fn is_low(&self) -> Result<bool, Self::Error> {
-            Ok(false)
-        }
-    }
-
-    pub struct OutputPin1_0;
-
-    impl eh1_0::digital::ErrorType for OutputPin1_0 {
-        type Error = Infallible;
-    }
-
-    impl eh1_0::digital::OutputPin for OutputPin1_0 {
-        /// Set the output as high
-        fn set_high(&mut self) -> Result<(), Self::Error> {
-            Ok(())
-        }
-
-        /// Set the output as low
-        fn set_low(&mut self) -> Result<(), Self::Error> {
-            Ok(())
-        }
-    }
-}

--- a/src/reverse.rs
+++ b/src/reverse.rs
@@ -178,6 +178,24 @@ mod spi {
             Ok(())
         }
     }
+
+    impl<T, E> eh0_2::spi::FullDuplex<u8> for Reverse<T>
+    where
+        T: eh1_0::spi::SpiBusRead<u8, Error = E> + eh1_0::spi::SpiBusWrite<u8, Error = E>,
+        E: Debug,
+    {
+        type Error = E;
+        fn read(&mut self) -> nb::Result<u8, Self::Error> {
+            let mut data = [0];
+            match self.inner.read(&mut data) {
+                Ok(_) => Ok(data[0]),
+                Err(e) => Err(nb::Error::Other(e)),
+            }
+        }
+        fn send(&mut self, word: u8) -> nb::Result<(), Self::Error> {
+            self.inner.write(&[word]).map_err(nb::Error::Other)
+        }
+    }
 }
 
 // I2C (blocking)

--- a/src/reverse.rs
+++ b/src/reverse.rs
@@ -264,4 +264,20 @@ mod serial {
             self.inner.flush()
         }
     }
+
+    impl<T, E> eh0_2::serial::Write<u8> for Reverse<T>
+    where
+        T: eh1_0::serial::Write<u8, Error = E>,
+        E: Debug,
+    {
+        type Error = E;
+
+        fn write(&mut self, word: u8) -> nb::Result<(), Self::Error> {
+            self.inner.write(&[word]).map_err(nb::Error::Other)
+        }
+
+        fn flush(&mut self) -> nb::Result<(), Self::Error> {
+            self.inner.flush().map_err(nb::Error::Other)
+        }
+    }
 }

--- a/tests/delay_forward.rs
+++ b/tests/delay_forward.rs
@@ -1,5 +1,3 @@
-use eh0_2;
-use eh1_0;
 use embedded_hal_compat::ForwardCompat;
 
 struct Peripheral;

--- a/tests/delay_forward.rs
+++ b/tests/delay_forward.rs
@@ -12,8 +12,8 @@ impl eh0_2::blocking::delay::DelayUs<u32> for Peripheral {
 
 #[test]
 fn can_forward() {
-    let p_0_2 = Peripheral;
-    let mut p_1_0 = p_0_2.forward();
-    eh1_0::delay::DelayUs::delay_ms(&mut p_1_0, 0);
-    eh1_0::delay::DelayUs::delay_ms(&mut p_1_0, 0);
+    let periph_0_2 = Peripheral;
+    let mut periph_1_0 = periph_0_2.forward();
+    eh1_0::delay::DelayUs::delay_ms(&mut periph_1_0, 0);
+    eh1_0::delay::DelayUs::delay_ms(&mut periph_1_0, 0);
 }

--- a/tests/delay_forward.rs
+++ b/tests/delay_forward.rs
@@ -1,0 +1,21 @@
+use eh0_2;
+use eh1_0;
+use embedded_hal_compat::ForwardCompat;
+
+struct Peripheral;
+
+impl eh0_2::blocking::delay::DelayMs<u32> for Peripheral {
+    fn delay_ms(&mut self, _ms: u32) {}
+}
+
+impl eh0_2::blocking::delay::DelayUs<u32> for Peripheral {
+    fn delay_us(&mut self, _us: u32) {}
+}
+
+#[test]
+fn can_forward() {
+    let p_0_2 = Peripheral;
+    let mut p_1_0 = p_0_2.forward();
+    eh1_0::delay::DelayUs::delay_ms(&mut p_1_0, 0);
+    eh1_0::delay::DelayUs::delay_ms(&mut p_1_0, 0);
+}

--- a/tests/delay_reverse.rs
+++ b/tests/delay_reverse.rs
@@ -1,0 +1,18 @@
+use eh0_2;
+use eh1_0;
+use embedded_hal_compat::ReverseCompat;
+
+struct Peripheral;
+
+impl eh1_0::delay::DelayUs for Peripheral {
+    fn delay_us(&mut self, _us: u32) {}
+    fn delay_ms(&mut self, _ms: u32) {}
+}
+
+#[test]
+fn can_reverse() {
+    let p_1_0 = Peripheral;
+    let mut p_0_2 = p_1_0.reverse();
+    eh0_2::blocking::delay::DelayMs::delay_ms(&mut p_0_2, 0_u32);
+    eh0_2::blocking::delay::DelayUs::delay_us(&mut p_0_2, 0_u32);
+}

--- a/tests/delay_reverse.rs
+++ b/tests/delay_reverse.rs
@@ -9,8 +9,8 @@ impl eh1_0::delay::DelayUs for Peripheral {
 
 #[test]
 fn can_reverse() {
-    let p_1_0 = Peripheral;
-    let mut p_0_2 = p_1_0.reverse();
-    eh0_2::blocking::delay::DelayMs::delay_ms(&mut p_0_2, 0_u32);
-    eh0_2::blocking::delay::DelayUs::delay_us(&mut p_0_2, 0_u32);
+    let periph_1_0 = Peripheral;
+    let mut periph_0_2 = periph_1_0.reverse();
+    eh0_2::blocking::delay::DelayMs::delay_ms(&mut periph_0_2, 0_u32);
+    eh0_2::blocking::delay::DelayUs::delay_us(&mut periph_0_2, 0_u32);
 }

--- a/tests/delay_reverse.rs
+++ b/tests/delay_reverse.rs
@@ -1,5 +1,3 @@
-use eh0_2;
-use eh1_0;
 use embedded_hal_compat::ReverseCompat;
 
 struct Peripheral;

--- a/tests/digital_forward.rs
+++ b/tests/digital_forward.rs
@@ -1,0 +1,46 @@
+use eh0_2;
+use eh1_0;
+use embedded_hal_compat::ForwardCompat;
+
+#[derive(Debug)]
+enum PinError {
+    _Something,
+}
+
+impl eh1_0::digital::Error for PinError {
+    fn kind(&self) -> eh1_0::digital::ErrorKind {
+        eh1_0::digital::ErrorKind::Other
+    }
+}
+
+struct Pin0;
+
+impl eh0_2::digital::v2::OutputPin for Pin0 {
+    type Error = PinError;
+
+    fn set_high(&mut self) -> Result<(), Self::Error> {
+        Ok(())
+    }
+    fn set_low(&mut self) -> Result<(), Self::Error> {
+        Ok(())
+    }
+}
+
+impl eh0_2::digital::v2::InputPin for Pin0 {
+    type Error = PinError;
+
+    fn is_high(&self) -> Result<bool, Self::Error> {
+        Ok(true)
+    }
+    fn is_low(&self) -> Result<bool, Self::Error> {
+        Ok(false)
+    }
+}
+
+#[test]
+fn can_forward() {
+    let p_0_2 = Pin0;
+    let mut p_1_0 = p_0_2.forward();
+    assert!(eh1_0::digital::OutputPin::set_high(&mut p_1_0).is_ok());
+    assert!(eh1_0::digital::InputPin::is_high(&p_1_0).unwrap());
+}

--- a/tests/digital_forward.rs
+++ b/tests/digital_forward.rs
@@ -1,5 +1,3 @@
-use eh0_2;
-use eh1_0;
 use embedded_hal_compat::ForwardCompat;
 
 #[derive(Debug)]

--- a/tests/digital_forward.rs
+++ b/tests/digital_forward.rs
@@ -11,9 +11,9 @@ impl eh1_0::digital::Error for PinError {
     }
 }
 
-struct Pin0;
+struct Peripheral;
 
-impl eh0_2::digital::v2::OutputPin for Pin0 {
+impl eh0_2::digital::v2::OutputPin for Peripheral {
     type Error = PinError;
 
     fn set_high(&mut self) -> Result<(), Self::Error> {
@@ -24,7 +24,7 @@ impl eh0_2::digital::v2::OutputPin for Pin0 {
     }
 }
 
-impl eh0_2::digital::v2::InputPin for Pin0 {
+impl eh0_2::digital::v2::InputPin for Peripheral {
     type Error = PinError;
 
     fn is_high(&self) -> Result<bool, Self::Error> {
@@ -37,8 +37,8 @@ impl eh0_2::digital::v2::InputPin for Pin0 {
 
 #[test]
 fn can_forward() {
-    let p_0_2 = Pin0;
-    let mut p_1_0 = p_0_2.forward();
-    assert!(eh1_0::digital::OutputPin::set_high(&mut p_1_0).is_ok());
-    assert!(eh1_0::digital::InputPin::is_high(&p_1_0).unwrap());
+    let periph_0_2 = Peripheral;
+    let mut periph_1_0 = periph_0_2.forward();
+    assert!(eh1_0::digital::OutputPin::set_high(&mut periph_1_0).is_ok());
+    assert!(eh1_0::digital::InputPin::is_high(&periph_1_0).unwrap());
 }

--- a/tests/digital_reverse.rs
+++ b/tests/digital_reverse.rs
@@ -1,0 +1,46 @@
+use eh0_2;
+use eh1_0;
+use embedded_hal_compat::ReverseCompat;
+
+#[derive(Debug)]
+enum PinError {
+    _Something,
+}
+
+impl eh1_0::digital::Error for PinError {
+    fn kind(&self) -> eh1_0::digital::ErrorKind {
+        eh1_0::digital::ErrorKind::Other
+    }
+}
+
+struct Pin0;
+
+impl eh1_0::digital::ErrorType for Pin0 {
+    type Error = PinError;
+}
+
+impl eh1_0::digital::OutputPin for Pin0 {
+    fn set_high(&mut self) -> Result<(), Self::Error> {
+        Ok(())
+    }
+    fn set_low(&mut self) -> Result<(), Self::Error> {
+        Ok(())
+    }
+}
+
+impl eh1_0::digital::InputPin for Pin0 {
+    fn is_high(&self) -> Result<bool, Self::Error> {
+        Ok(true)
+    }
+    fn is_low(&self) -> Result<bool, Self::Error> {
+        Ok(false)
+    }
+}
+
+#[test]
+fn can_reverse() {
+    let p_1_0 = Pin0;
+    let mut p_0_2 = p_1_0.reverse();
+    assert!(eh0_2::digital::v2::OutputPin::set_high(&mut p_0_2).is_ok());
+    assert!(eh0_2::digital::v2::InputPin::is_high(&p_0_2).unwrap());
+}

--- a/tests/digital_reverse.rs
+++ b/tests/digital_reverse.rs
@@ -11,13 +11,13 @@ impl eh1_0::digital::Error for PinError {
     }
 }
 
-struct Pin0;
+struct Peripheral;
 
-impl eh1_0::digital::ErrorType for Pin0 {
+impl eh1_0::digital::ErrorType for Peripheral {
     type Error = PinError;
 }
 
-impl eh1_0::digital::OutputPin for Pin0 {
+impl eh1_0::digital::OutputPin for Peripheral {
     fn set_high(&mut self) -> Result<(), Self::Error> {
         Ok(())
     }
@@ -26,7 +26,7 @@ impl eh1_0::digital::OutputPin for Pin0 {
     }
 }
 
-impl eh1_0::digital::InputPin for Pin0 {
+impl eh1_0::digital::InputPin for Peripheral {
     fn is_high(&self) -> Result<bool, Self::Error> {
         Ok(true)
     }
@@ -37,8 +37,8 @@ impl eh1_0::digital::InputPin for Pin0 {
 
 #[test]
 fn can_reverse() {
-    let p_1_0 = Pin0;
-    let mut p_0_2 = p_1_0.reverse();
-    assert!(eh0_2::digital::v2::OutputPin::set_high(&mut p_0_2).is_ok());
-    assert!(eh0_2::digital::v2::InputPin::is_high(&p_0_2).unwrap());
+    let periph_1_0 = Peripheral;
+    let mut periph_0_2 = periph_1_0.reverse();
+    assert!(eh0_2::digital::v2::OutputPin::set_high(&mut periph_0_2).is_ok());
+    assert!(eh0_2::digital::v2::InputPin::is_high(&periph_0_2).unwrap());
 }

--- a/tests/digital_reverse.rs
+++ b/tests/digital_reverse.rs
@@ -1,5 +1,3 @@
-use eh0_2;
-use eh1_0;
 use embedded_hal_compat::ReverseCompat;
 
 #[derive(Debug)]

--- a/tests/i2c_forward.rs
+++ b/tests/i2c_forward.rs
@@ -1,5 +1,3 @@
-use eh0_2;
-use eh1_0;
 use embedded_hal_compat::ForwardCompat;
 
 #[derive(Debug)]
@@ -68,10 +66,10 @@ impl eh0_2::blocking::i2c::WriteIterRead for I2c0 {
 
 impl eh0_2::blocking::i2c::Transactional for I2c0 {
     type Error = ImplError;
-    fn exec<'a>(
+    fn exec(
         &mut self,
         _address: u8,
-        _operations: &mut [eh0_2::blocking::i2c::Operation<'a>],
+        _operations: &mut [eh0_2::blocking::i2c::Operation],
     ) -> Result<(), Self::Error> {
         Ok(())
     }

--- a/tests/i2c_forward.rs
+++ b/tests/i2c_forward.rs
@@ -11,23 +11,23 @@ impl eh1_0::i2c::Error for ImplError {
     }
 }
 
-struct I2c0;
+struct Peripheral;
 
-impl eh0_2::blocking::i2c::Write for I2c0 {
+impl eh0_2::blocking::i2c::Write for Peripheral {
     type Error = ImplError;
     fn write(&mut self, _address: u8, _bytes: &[u8]) -> Result<(), Self::Error> {
         Ok(())
     }
 }
 
-impl eh0_2::blocking::i2c::Read for I2c0 {
+impl eh0_2::blocking::i2c::Read for Peripheral {
     type Error = ImplError;
     fn read(&mut self, _address: u8, _buffer: &mut [u8]) -> Result<(), Self::Error> {
         Ok(())
     }
 }
 
-impl eh0_2::blocking::i2c::WriteRead for I2c0 {
+impl eh0_2::blocking::i2c::WriteRead for Peripheral {
     type Error = ImplError;
     fn write_read(
         &mut self,
@@ -39,7 +39,7 @@ impl eh0_2::blocking::i2c::WriteRead for I2c0 {
     }
 }
 
-impl eh0_2::blocking::i2c::WriteIter for I2c0 {
+impl eh0_2::blocking::i2c::WriteIter for Peripheral {
     type Error = ImplError;
     fn write<B>(&mut self, _address: u8, _bytes: B) -> Result<(), Self::Error>
     where
@@ -49,7 +49,7 @@ impl eh0_2::blocking::i2c::WriteIter for I2c0 {
     }
 }
 
-impl eh0_2::blocking::i2c::WriteIterRead for I2c0 {
+impl eh0_2::blocking::i2c::WriteIterRead for Peripheral {
     type Error = ImplError;
     fn write_iter_read<B>(
         &mut self,
@@ -64,7 +64,7 @@ impl eh0_2::blocking::i2c::WriteIterRead for I2c0 {
     }
 }
 
-impl eh0_2::blocking::i2c::Transactional for I2c0 {
+impl eh0_2::blocking::i2c::Transactional for Peripheral {
     type Error = ImplError;
     fn exec(
         &mut self,
@@ -75,7 +75,7 @@ impl eh0_2::blocking::i2c::Transactional for I2c0 {
     }
 }
 
-impl eh0_2::blocking::i2c::TransactionalIter for I2c0 {
+impl eh0_2::blocking::i2c::TransactionalIter for Peripheral {
     type Error = ImplError;
     fn exec_iter<'a, O>(&mut self, _address: u8, _operations: O) -> Result<(), Self::Error>
     where
@@ -88,10 +88,10 @@ impl eh0_2::blocking::i2c::TransactionalIter for I2c0 {
 #[test]
 fn can_forward() {
     let mut data = [];
-    let i2c_0_2 = I2c0;
-    let mut i2c_1_0 = i2c_0_2.forward();
-    assert!(eh1_0::i2c::I2c::write(&mut i2c_1_0, 0, &[]).is_ok());
-    assert!(eh1_0::i2c::I2c::write_read(&mut i2c_1_0, 0, &[], &mut data).is_ok());
-    assert!(eh1_0::i2c::I2c::read(&mut i2c_1_0, 0, &mut data).is_ok());
-    assert!(eh1_0::i2c::I2c::transaction(&mut i2c_1_0, 0, &mut []).is_ok());
+    let periph_0_2 = Peripheral;
+    let mut periph_1_0 = periph_0_2.forward();
+    assert!(eh1_0::i2c::I2c::write(&mut periph_1_0, 0, &[]).is_ok());
+    assert!(eh1_0::i2c::I2c::write_read(&mut periph_1_0, 0, &[], &mut data).is_ok());
+    assert!(eh1_0::i2c::I2c::read(&mut periph_1_0, 0, &mut data).is_ok());
+    assert!(eh1_0::i2c::I2c::transaction(&mut periph_1_0, 0, &mut []).is_ok());
 }

--- a/tests/i2c_forward.rs
+++ b/tests/i2c_forward.rs
@@ -1,0 +1,99 @@
+use eh0_2;
+use eh1_0;
+use embedded_hal_compat::ForwardCompat;
+
+#[derive(Debug)]
+enum ImplError {
+    _Something,
+}
+
+impl eh1_0::i2c::Error for ImplError {
+    fn kind(&self) -> eh1_0::i2c::ErrorKind {
+        eh1_0::i2c::ErrorKind::Other
+    }
+}
+
+struct I2c0;
+
+impl eh0_2::blocking::i2c::Write for I2c0 {
+    type Error = ImplError;
+    fn write(&mut self, _address: u8, _bytes: &[u8]) -> Result<(), Self::Error> {
+        Ok(())
+    }
+}
+
+impl eh0_2::blocking::i2c::Read for I2c0 {
+    type Error = ImplError;
+    fn read(&mut self, _address: u8, _buffer: &mut [u8]) -> Result<(), Self::Error> {
+        Ok(())
+    }
+}
+
+impl eh0_2::blocking::i2c::WriteRead for I2c0 {
+    type Error = ImplError;
+    fn write_read(
+        &mut self,
+        _address: u8,
+        _bytes: &[u8],
+        _buffer: &mut [u8],
+    ) -> Result<(), Self::Error> {
+        Ok(())
+    }
+}
+
+impl eh0_2::blocking::i2c::WriteIter for I2c0 {
+    type Error = ImplError;
+    fn write<B>(&mut self, _address: u8, _bytes: B) -> Result<(), Self::Error>
+    where
+        B: IntoIterator<Item = u8>,
+    {
+        Ok(())
+    }
+}
+
+impl eh0_2::blocking::i2c::WriteIterRead for I2c0 {
+    type Error = ImplError;
+    fn write_iter_read<B>(
+        &mut self,
+        _address: u8,
+        _bytes: B,
+        _buffer: &mut [u8],
+    ) -> Result<(), Self::Error>
+    where
+        B: IntoIterator<Item = u8>,
+    {
+        Ok(())
+    }
+}
+
+impl eh0_2::blocking::i2c::Transactional for I2c0 {
+    type Error = ImplError;
+    fn exec<'a>(
+        &mut self,
+        _address: u8,
+        _operations: &mut [eh0_2::blocking::i2c::Operation<'a>],
+    ) -> Result<(), Self::Error> {
+        Ok(())
+    }
+}
+
+impl eh0_2::blocking::i2c::TransactionalIter for I2c0 {
+    type Error = ImplError;
+    fn exec_iter<'a, O>(&mut self, _address: u8, _operations: O) -> Result<(), Self::Error>
+    where
+        O: IntoIterator<Item = eh0_2::blocking::i2c::Operation<'a>>,
+    {
+        Ok(())
+    }
+}
+
+#[test]
+fn can_forward() {
+    let mut data = [];
+    let i2c_0_2 = I2c0;
+    let mut i2c_1_0 = i2c_0_2.forward();
+    assert!(eh1_0::i2c::I2c::write(&mut i2c_1_0, 0, &[]).is_ok());
+    assert!(eh1_0::i2c::I2c::write_read(&mut i2c_1_0, 0, &[], &mut data).is_ok());
+    assert!(eh1_0::i2c::I2c::read(&mut i2c_1_0, 0, &mut data).is_ok());
+    assert!(eh1_0::i2c::I2c::transaction(&mut i2c_1_0, 0, &mut []).is_ok());
+}

--- a/tests/i2c_reverse.rs
+++ b/tests/i2c_reverse.rs
@@ -50,6 +50,8 @@ fn can_reverse() {
     let periph_1_0 = Peripheral;
     let mut periph_0_2 = periph_1_0.reverse();
     assert!(eh0_2::blocking::i2c::Write::write(&mut periph_0_2, 0, &[]).is_ok());
-    assert!(eh0_2::blocking::i2c::WriteRead::write_read(&mut periph_0_2, 0, &[], &mut data).is_ok());
+    assert!(
+        eh0_2::blocking::i2c::WriteRead::write_read(&mut periph_0_2, 0, &[], &mut data).is_ok()
+    );
     assert!(eh0_2::blocking::i2c::Read::read(&mut periph_0_2, 0, &mut data).is_ok());
 }

--- a/tests/i2c_reverse.rs
+++ b/tests/i2c_reverse.rs
@@ -11,13 +11,13 @@ impl eh1_0::i2c::Error for ImplError {
     }
 }
 
-struct I2c0;
+struct Peripheral;
 
-impl eh1_0::i2c::ErrorType for I2c0 {
+impl eh1_0::i2c::ErrorType for Peripheral {
     type Error = ImplError;
 }
 
-impl eh1_0::i2c::I2c for I2c0 {
+impl eh1_0::i2c::I2c for Peripheral {
     fn read(&mut self, _address: u8, _read: &mut [u8]) -> Result<(), Self::Error> {
         Ok(())
     }
@@ -47,9 +47,9 @@ impl eh1_0::i2c::I2c for I2c0 {
 #[test]
 fn can_reverse() {
     let mut data = [];
-    let i2c_1_0 = I2c0;
-    let mut i2c_0_2 = i2c_1_0.reverse();
-    assert!(eh0_2::blocking::i2c::Write::write(&mut i2c_0_2, 0, &[]).is_ok());
-    assert!(eh0_2::blocking::i2c::WriteRead::write_read(&mut i2c_0_2, 0, &[], &mut data).is_ok());
-    assert!(eh0_2::blocking::i2c::Read::read(&mut i2c_0_2, 0, &mut data).is_ok());
+    let periph_1_0 = Peripheral;
+    let mut periph_0_2 = periph_1_0.reverse();
+    assert!(eh0_2::blocking::i2c::Write::write(&mut periph_0_2, 0, &[]).is_ok());
+    assert!(eh0_2::blocking::i2c::WriteRead::write_read(&mut periph_0_2, 0, &[], &mut data).is_ok());
+    assert!(eh0_2::blocking::i2c::Read::read(&mut periph_0_2, 0, &mut data).is_ok());
 }

--- a/tests/i2c_reverse.rs
+++ b/tests/i2c_reverse.rs
@@ -1,0 +1,57 @@
+use eh0_2;
+use eh1_0;
+use embedded_hal_compat::ReverseCompat;
+
+#[derive(Debug)]
+enum ImplError {
+    _Something,
+}
+
+impl eh1_0::i2c::Error for ImplError {
+    fn kind(&self) -> eh1_0::i2c::ErrorKind {
+        eh1_0::i2c::ErrorKind::Other
+    }
+}
+
+struct I2c0;
+
+impl eh1_0::i2c::ErrorType for I2c0 {
+    type Error = ImplError;
+}
+
+impl eh1_0::i2c::I2c for I2c0 {
+    fn read(&mut self, _address: u8, _read: &mut [u8]) -> Result<(), Self::Error> {
+        Ok(())
+    }
+
+    fn write(&mut self, _address: u8, _write: &[u8]) -> Result<(), Self::Error> {
+        Ok(())
+    }
+
+    fn transaction(
+        &mut self,
+        _address: u8,
+        _operations: &mut [eh1_0::i2c::Operation<'_>],
+    ) -> Result<(), Self::Error> {
+        Ok(())
+    }
+
+    fn write_read(
+        &mut self,
+        _address: u8,
+        _write: &[u8],
+        _read: &mut [u8],
+    ) -> Result<(), Self::Error> {
+        Ok(())
+    }
+}
+
+#[test]
+fn can_reverse() {
+    let mut data = [];
+    let i2c_1_0 = I2c0;
+    let mut i2c_0_2 = i2c_1_0.reverse();
+    assert!(eh0_2::blocking::i2c::Write::write(&mut i2c_0_2, 0, &[]).is_ok());
+    assert!(eh0_2::blocking::i2c::WriteRead::write_read(&mut i2c_0_2, 0, &[], &mut data).is_ok());
+    assert!(eh0_2::blocking::i2c::Read::read(&mut i2c_0_2, 0, &mut data).is_ok());
+}

--- a/tests/i2c_reverse.rs
+++ b/tests/i2c_reverse.rs
@@ -1,5 +1,3 @@
-use eh0_2;
-use eh1_0;
 use embedded_hal_compat::ReverseCompat;
 
 #[derive(Debug)]

--- a/tests/serial_forward.rs
+++ b/tests/serial_forward.rs
@@ -37,8 +37,8 @@ impl eh0_2::serial::Write<u8> for Peripheral {
 
 #[test]
 fn can_forward() {
-    let p_0_2 = Peripheral;
-    let mut p_1_0 = p_0_2.forward();
-    assert!(eh1_0::serial::Write::write(&mut p_1_0, &[0]).is_ok());
-    assert!(eh1_0::serial::Write::flush(&mut p_1_0).is_ok());
+    let periph_0_2 = Peripheral;
+    let mut periph_1_0 = periph_0_2.forward();
+    assert!(eh1_0::serial::Write::write(&mut periph_1_0, &[0]).is_ok());
+    assert!(eh1_0::serial::Write::flush(&mut periph_1_0).is_ok());
 }

--- a/tests/serial_forward.rs
+++ b/tests/serial_forward.rs
@@ -1,5 +1,3 @@
-use eh0_2;
-use eh1_0;
 use embedded_hal_compat::ForwardCompat;
 
 #[derive(Debug)]

--- a/tests/serial_forward.rs
+++ b/tests/serial_forward.rs
@@ -1,0 +1,46 @@
+use eh0_2;
+use eh1_0;
+use embedded_hal_compat::ForwardCompat;
+
+#[derive(Debug)]
+enum ImplError {
+    _Something,
+}
+
+impl eh1_0::serial::Error for ImplError {
+    fn kind(&self) -> eh1_0::serial::ErrorKind {
+        eh1_0::serial::ErrorKind::Other
+    }
+}
+
+struct Peripheral;
+
+impl eh0_2::blocking::serial::Write<u8> for Peripheral {
+    type Error = ImplError;
+
+    fn bwrite_all(&mut self, _buffer: &[u8]) -> Result<(), Self::Error> {
+        Ok(())
+    }
+    fn bflush(&mut self) -> Result<(), Self::Error> {
+        Ok(())
+    }
+}
+
+impl eh0_2::serial::Write<u8> for Peripheral {
+    type Error = ImplError;
+
+    fn write(&mut self, _word: u8) -> nb::Result<(), Self::Error> {
+        Ok(())
+    }
+    fn flush(&mut self) -> nb::Result<(), Self::Error> {
+        Ok(())
+    }
+}
+
+#[test]
+fn can_forward() {
+    let p_0_2 = Peripheral;
+    let mut p_1_0 = p_0_2.forward();
+    assert!(eh1_0::serial::Write::write(&mut p_1_0, &[0]).is_ok());
+    assert!(eh1_0::serial::Write::flush(&mut p_1_0).is_ok());
+}

--- a/tests/serial_reverse.rs
+++ b/tests/serial_reverse.rs
@@ -28,10 +28,10 @@ impl eh1_0::serial::Write<u8> for Peripheral {
 
 #[test]
 fn can_reverse() {
-    let p_1_0 = Peripheral;
-    let mut p_0_2 = p_1_0.reverse();
-    assert!(eh0_2::blocking::serial::Write::bflush(&mut p_0_2).is_ok());
-    assert!(eh0_2::blocking::serial::Write::bwrite_all(&mut p_0_2, &[]).is_ok());
-    assert!(eh0_2::serial::Write::write(&mut p_0_2, 0).is_ok());
-    assert!(eh0_2::serial::Write::flush(&mut p_0_2).is_ok());
+    let periph_1_0 = Peripheral;
+    let mut periph_0_2 = periph_1_0.reverse();
+    assert!(eh0_2::blocking::serial::Write::bflush(&mut periph_0_2).is_ok());
+    assert!(eh0_2::blocking::serial::Write::bwrite_all(&mut periph_0_2, &[]).is_ok());
+    assert!(eh0_2::serial::Write::write(&mut periph_0_2, 0).is_ok());
+    assert!(eh0_2::serial::Write::flush(&mut periph_0_2).is_ok());
 }

--- a/tests/serial_reverse.rs
+++ b/tests/serial_reverse.rs
@@ -1,5 +1,3 @@
-use eh0_2;
-use eh1_0;
 use embedded_hal_compat::ReverseCompat;
 
 #[derive(Debug)]

--- a/tests/serial_reverse.rs
+++ b/tests/serial_reverse.rs
@@ -1,0 +1,39 @@
+use eh0_2;
+use eh1_0;
+use embedded_hal_compat::ReverseCompat;
+
+#[derive(Debug)]
+enum ImplError {
+    _Something,
+}
+
+impl eh1_0::serial::Error for ImplError {
+    fn kind(&self) -> eh1_0::serial::ErrorKind {
+        eh1_0::serial::ErrorKind::Other
+    }
+}
+
+struct Peripheral;
+
+impl eh1_0::serial::ErrorType for Peripheral {
+    type Error = ImplError;
+}
+
+impl eh1_0::serial::Write<u8> for Peripheral {
+    fn write(&mut self, _buffer: &[u8]) -> Result<(), Self::Error> {
+        Ok(())
+    }
+    fn flush(&mut self) -> Result<(), Self::Error> {
+        Ok(())
+    }
+}
+
+#[test]
+fn can_reverse() {
+    let p_1_0 = Peripheral;
+    let mut p_0_2 = p_1_0.reverse();
+    assert!(eh0_2::blocking::serial::Write::bflush(&mut p_0_2).is_ok());
+    assert!(eh0_2::blocking::serial::Write::bwrite_all(&mut p_0_2, &[]).is_ok());
+    assert!(eh0_2::serial::Write::write(&mut p_0_2, 0).is_ok());
+    assert!(eh0_2::serial::Write::flush(&mut p_0_2).is_ok());
+}

--- a/tests/spi_forward.rs
+++ b/tests/spi_forward.rs
@@ -1,5 +1,3 @@
-use eh0_2;
-use eh1_0;
 use embedded_hal_compat::ForwardCompat;
 
 #[derive(Debug)]
@@ -57,6 +55,6 @@ fn can_forward() {
     assert!(eh1_0::spi::SpiBusWrite::write(&mut spi_1_0, &[]).is_ok());
     assert!(eh1_0::spi::SpiBusRead::read(&mut spi_1_0, &mut []).is_ok());
     assert!(eh1_0::spi::SpiBusFlush::flush(&mut spi_1_0).is_ok());
-    assert!(eh1_0::spi::SpiBus::transfer(&mut spi_1_0, &mut [], &mut []).is_ok());
+    assert!(eh1_0::spi::SpiBus::transfer(&mut spi_1_0, &mut [], &[]).is_ok());
     assert!(eh1_0::spi::SpiBus::transfer_in_place(&mut spi_1_0, &mut []).is_ok());
 }

--- a/tests/spi_forward.rs
+++ b/tests/spi_forward.rs
@@ -11,23 +11,23 @@ impl eh1_0::spi::Error for ImplError {
     }
 }
 
-struct Spi0;
+struct Peripheral;
 
-impl eh0_2::blocking::spi::Write<u8> for Spi0 {
+impl eh0_2::blocking::spi::Write<u8> for Peripheral {
     type Error = ImplError;
     fn write(&mut self, _words: &[u8]) -> Result<(), Self::Error> {
         Ok(())
     }
 }
 
-impl eh0_2::blocking::spi::Transfer<u8> for Spi0 {
+impl eh0_2::blocking::spi::Transfer<u8> for Peripheral {
     type Error = ImplError;
     fn transfer<'w>(&mut self, words: &'w mut [u8]) -> Result<&'w [u8], Self::Error> {
         Ok(words)
     }
 }
 
-impl eh0_2::blocking::spi::WriteIter<u8> for Spi0 {
+impl eh0_2::blocking::spi::WriteIter<u8> for Peripheral {
     type Error = ImplError;
     fn write_iter<WI>(&mut self, _words: WI) -> Result<(), Self::Error>
     where
@@ -37,7 +37,7 @@ impl eh0_2::blocking::spi::WriteIter<u8> for Spi0 {
     }
 }
 
-impl eh0_2::spi::FullDuplex<u8> for Spi0 {
+impl eh0_2::spi::FullDuplex<u8> for Peripheral {
     type Error = ImplError;
 
     fn read(&mut self) -> nb::Result<u8, Self::Error> {
@@ -50,11 +50,11 @@ impl eh0_2::spi::FullDuplex<u8> for Spi0 {
 
 #[test]
 fn can_forward() {
-    let spi_0_2 = Spi0;
-    let mut spi_1_0 = spi_0_2.forward();
-    assert!(eh1_0::spi::SpiBusWrite::write(&mut spi_1_0, &[]).is_ok());
-    assert!(eh1_0::spi::SpiBusRead::read(&mut spi_1_0, &mut []).is_ok());
-    assert!(eh1_0::spi::SpiBusFlush::flush(&mut spi_1_0).is_ok());
-    assert!(eh1_0::spi::SpiBus::transfer(&mut spi_1_0, &mut [], &[]).is_ok());
-    assert!(eh1_0::spi::SpiBus::transfer_in_place(&mut spi_1_0, &mut []).is_ok());
+    let periph_0_2 = Peripheral;
+    let mut periph_1_0 = periph_0_2.forward();
+    assert!(eh1_0::spi::SpiBusWrite::write(&mut periph_1_0, &[]).is_ok());
+    assert!(eh1_0::spi::SpiBusRead::read(&mut periph_1_0, &mut []).is_ok());
+    assert!(eh1_0::spi::SpiBusFlush::flush(&mut periph_1_0).is_ok());
+    assert!(eh1_0::spi::SpiBus::transfer(&mut periph_1_0, &mut [], &[]).is_ok());
+    assert!(eh1_0::spi::SpiBus::transfer_in_place(&mut periph_1_0, &mut []).is_ok());
 }

--- a/tests/spi_forward.rs
+++ b/tests/spi_forward.rs
@@ -1,0 +1,62 @@
+use eh0_2;
+use eh1_0;
+use embedded_hal_compat::ForwardCompat;
+
+#[derive(Debug)]
+enum ImplError {
+    _Something,
+}
+
+impl eh1_0::spi::Error for ImplError {
+    fn kind(&self) -> eh1_0::spi::ErrorKind {
+        eh1_0::spi::ErrorKind::Other
+    }
+}
+
+struct Spi0;
+
+impl eh0_2::blocking::spi::Write<u8> for Spi0 {
+    type Error = ImplError;
+    fn write(&mut self, _words: &[u8]) -> Result<(), Self::Error> {
+        Ok(())
+    }
+}
+
+impl eh0_2::blocking::spi::Transfer<u8> for Spi0 {
+    type Error = ImplError;
+    fn transfer<'w>(&mut self, words: &'w mut [u8]) -> Result<&'w [u8], Self::Error> {
+        Ok(words)
+    }
+}
+
+impl eh0_2::blocking::spi::WriteIter<u8> for Spi0 {
+    type Error = ImplError;
+    fn write_iter<WI>(&mut self, _words: WI) -> Result<(), Self::Error>
+    where
+        WI: IntoIterator<Item = u8>,
+    {
+        Ok(())
+    }
+}
+
+impl eh0_2::spi::FullDuplex<u8> for Spi0 {
+    type Error = ImplError;
+
+    fn read(&mut self) -> nb::Result<u8, Self::Error> {
+        Ok(0)
+    }
+    fn send(&mut self, _word: u8) -> nb::Result<(), Self::Error> {
+        Ok(())
+    }
+}
+
+#[test]
+fn can_forward() {
+    let spi_0_2 = Spi0;
+    let mut spi_1_0 = spi_0_2.forward();
+    assert!(eh1_0::spi::SpiBusWrite::write(&mut spi_1_0, &[]).is_ok());
+    assert!(eh1_0::spi::SpiBusRead::read(&mut spi_1_0, &mut []).is_ok());
+    assert!(eh1_0::spi::SpiBusFlush::flush(&mut spi_1_0).is_ok());
+    assert!(eh1_0::spi::SpiBus::transfer(&mut spi_1_0, &mut [], &mut []).is_ok());
+    assert!(eh1_0::spi::SpiBus::transfer_in_place(&mut spi_1_0, &mut []).is_ok());
+}

--- a/tests/spi_reverse.rs
+++ b/tests/spi_reverse.rs
@@ -1,0 +1,57 @@
+use eh0_2;
+use eh1_0;
+use embedded_hal_compat::ReverseCompat;
+
+#[derive(Debug)]
+enum ImplError {
+    _Something,
+}
+
+impl eh1_0::spi::Error for ImplError {
+    fn kind(&self) -> eh1_0::spi::ErrorKind {
+        eh1_0::spi::ErrorKind::Other
+    }
+}
+
+struct Peripheral;
+
+impl eh1_0::spi::ErrorType for Peripheral {
+    type Error = ImplError;
+}
+
+impl eh1_0::spi::SpiBusRead for Peripheral {
+    fn read(&mut self, _words: &mut [u8]) -> Result<(), Self::Error> {
+        Ok(())
+    }
+}
+
+impl eh1_0::spi::SpiBusWrite for Peripheral {
+    fn write(&mut self, _words: &[u8]) -> Result<(), Self::Error> {
+        Ok(())
+    }
+}
+
+impl eh1_0::spi::SpiBusFlush for Peripheral {
+    fn flush(&mut self) -> Result<(), Self::Error> {
+        Ok(())
+    }
+}
+
+impl eh1_0::spi::SpiBus for Peripheral {
+    fn transfer(&mut self, _read: &mut [u8], _write: &[u8]) -> Result<(), Self::Error> {
+        Ok(())
+    }
+    fn transfer_in_place(&mut self, _words: &mut [u8]) -> Result<(), Self::Error> {
+        Ok(())
+    }
+}
+
+#[test]
+fn can_reverse() {
+    let data = [];
+    let periph_1_0 = Peripheral;
+    let mut periph_0_2 = periph_1_0.reverse();
+    assert!(eh0_2::blocking::spi::Write::write(&mut periph_0_2, &[]).is_ok());
+    assert!(eh0_2::blocking::spi::Transfer::transfer(&mut periph_0_2, &mut []).is_ok());
+    assert!(eh0_2::blocking::spi::WriteIter::write_iter(&mut periph_0_2, data).is_ok());
+}

--- a/tests/spi_reverse.rs
+++ b/tests/spi_reverse.rs
@@ -54,4 +54,6 @@ fn can_reverse() {
     assert!(eh0_2::blocking::spi::Write::write(&mut periph_0_2, &[]).is_ok());
     assert!(eh0_2::blocking::spi::Transfer::transfer(&mut periph_0_2, &mut []).is_ok());
     assert!(eh0_2::blocking::spi::WriteIter::write_iter(&mut periph_0_2, data).is_ok());
+    assert!(eh0_2::spi::FullDuplex::send(&mut periph_0_2, 0).is_ok());
+    assert_eq!(eh0_2::spi::FullDuplex::read(&mut periph_0_2).unwrap(), 0);
 }

--- a/tests/spi_reverse.rs
+++ b/tests/spi_reverse.rs
@@ -1,5 +1,3 @@
-use eh0_2;
-use eh1_0;
 use embedded_hal_compat::ReverseCompat;
 
 #[derive(Debug)]


### PR DESCRIPTION
I fixed #18, then one thing led to the other and here we are :)

A summary of this PR is:
- Fix for #18 
- Added implementations for `spi::FullDuplex` and `serial::Write` for reverse compatibility
- Removed docs-only `mock` module
- Fix clippy warnings
- Add changelog
- Freshen-up and expand CI
- Unit tests
- Added license file
- Added myself as author

Sorry for the monster PR, it is hopefully uncontroversial :)

Fixes #18 