### PR TITLE
Support I2C/SPI Transactional traits for reverse compatibility

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -33,7 +33,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        rust: [stable, beta, 1.60.0]
+        rust: [stable, 1.60.0]
+        features: ["", "--features alloc"]
         TARGET:
           - x86_64-unknown-linux-gnu
           - x86_64-unknown-linux-musl
@@ -52,14 +53,15 @@ jobs:
           toolchain: ${{ matrix.rust }}
           targets: ${{ matrix.TARGET }}
 
-      - run: cargo build --target=${{ matrix.TARGET }}
+      - run: cargo build ${{matrix.features}} --target=${{ matrix.TARGET }}
 
   test:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        rust: [stable, beta]
-        TARGET: [x86_64-unknown-linux-gnu, x86_64-unknown-linux-musl]
+        rust: [stable]
+        features: ["", "--features alloc"]
+        TARGET: [x86_64-unknown-linux-gnu]
 
     steps:
       - uses: actions/checkout@v3
@@ -68,4 +70,4 @@ jobs:
           toolchain: ${{ matrix.rust }}
           targets: ${{ matrix.TARGET }}
 
-      - run: cargo test --target=${{ matrix.TARGET }}
+      - run: cargo test ${{matrix.features}} --target=${{ matrix.TARGET }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 - SPI `FullDuplex` trait implementation for reverse compatibility.
 - Serial non-blocking `Write` trait implementation for reverse compatibility.
+- I2C and SPI `Transactional` trait implementations for reverse compatibility (needs `alloc`).
 - Unit tests.
 
 ### Removed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,9 @@ authors = ["Ryan Kurte <ryan@kurte.nz>", "Diego Barrios Romero <eldruin@gmail.co
 edition = "2018"
 license = "MIT"
 
+[features]
+alloc = []
+
 [dependencies]
 defmt = { version = "0.3.0", optional = true }
 nb = "1.1"
@@ -20,3 +23,9 @@ features = [ "unproven" ]
 [dependencies.eh1_0]
 package = "embedded-hal"
 version = "=1.0.0-alpha.10"
+
+[package.metadata.docs.rs]
+# To build locally:
+# RUSTDOCFLAGS="--cfg docsrs" cargo +nightly doc --all-features --no-deps --open
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -95,7 +95,23 @@
 //! // Access via e-h v0.2.x methods
 //! let _ = eh0_2::digital::v2::OutputPin::set_high(&mut old);
 //!```
+//!
+//! ## Optional features
+//! ### `alloc`
+//! The `alloc` feature enables an implementation of the I2C and SPI `Transactional`
+//! traits from `embedded-hal` `v0.2.x` for the "reverse" direction.
+//!
+//! For example, when your MCU implements the`embedded-hal` `1.0.0` traits
+//! and you want to connect with an I2C or SPI driver that uses
+//! the `Transactional` traits of `embedded-hal` `0.2.x`.
+//!
+//! **For all other cases, this feature is unnecessary**.
+//!
+//! Do not enable it if you do not need it.
+//!
+//! Note that this introduces a dependency on the [core allocation library](https://doc.rust-lang.org/alloc/).
 
+#![cfg_attr(docsrs, feature(doc_cfg))]
 #![no_std]
 
 /// Re-export of the linked embedded-hal `v0.2.x` version for convenience

--- a/tests/i2c_reverse.rs
+++ b/tests/i2c_reverse.rs
@@ -54,4 +54,6 @@ fn can_reverse() {
         eh0_2::blocking::i2c::WriteRead::write_read(&mut periph_0_2, 0, &[], &mut data).is_ok()
     );
     assert!(eh0_2::blocking::i2c::Read::read(&mut periph_0_2, 0, &mut data).is_ok());
+    #[cfg(feature = "alloc")]
+    assert!(eh0_2::blocking::i2c::Transactional::exec(&mut periph_0_2, 0, &mut []).is_ok());
 }

--- a/tests/spi_reverse.rs
+++ b/tests/spi_reverse.rs
@@ -55,3 +55,42 @@ fn can_reverse() {
     assert!(eh0_2::spi::FullDuplex::send(&mut periph_0_2, 0).is_ok());
     assert_eq!(eh0_2::spi::FullDuplex::read(&mut periph_0_2).unwrap(), 0);
 }
+
+#[cfg(feature = "alloc")]
+#[test]
+fn can_perform_trasaction_reverse() {
+    let mut read0 = [2; 3];
+    let mut read1 = [4; 3];
+    let periph_1_0 = Peripheral;
+    let mut periph_0_2 = periph_1_0.reverse();
+
+    let mut ops = [
+        eh0_2::blocking::spi::Operation::Write(&[1; 5]),
+        eh0_2::blocking::spi::Operation::Transfer(&mut read0),
+        eh0_2::blocking::spi::Operation::Write(&[3; 7]),
+        eh0_2::blocking::spi::Operation::Transfer(&mut read1),
+    ];
+
+    assert!(eh0_2::blocking::spi::Transactional::exec(&mut periph_0_2, &mut ops).is_ok());
+
+    if let eh0_2::blocking::spi::Operation::Write(buf) = ops[0] {
+        assert_eq!(buf, [1; 5]);
+    } else {
+        panic!();
+    }
+    if let eh0_2::blocking::spi::Operation::Transfer(ref buf) = ops[1] {
+        assert_eq!(*buf, [2; 3]);
+    } else {
+        panic!();
+    }
+    if let eh0_2::blocking::spi::Operation::Write(buf) = ops[2] {
+        assert_eq!(buf, [3; 7]);
+    } else {
+        panic!();
+    }
+    if let eh0_2::blocking::spi::Operation::Transfer(ref buf) = ops[3] {
+        assert_eq!(*buf, [4; 3]);
+    } else {
+        panic!();
+    }
+}


### PR DESCRIPTION
I reduced a the CI configurations because with the feature variations it was a bit too many.
Maybe we can get this into the 0.10.1 release as well.

Fixes #21 