### PR TITLE
added marker type to Forward to support constraining gpio impls

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,5 +1,10 @@
 name: tests
-on: [push, pull_request]
+on:
+  push:
+    branches: [ main ]
+    tags: [ 'v*' ]
+  pull_request:
+    branches: [ main ]
 
 env:
   RUSTFLAGS: '--deny warnings'

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,6 +17,9 @@
 //! use with `v1.0.x` consumers, so you can drop these wrapped types into drivers expecting
 //! `v1.0.x` types.
 //!
+//! Note that GPIO pins will require annotation with marker types (see [markers]) to select
+//! input / output / combined modes.
+//!
 //!```
 //! # use core::convert::Infallible;
 //! # pub struct OutputPin0_2;
@@ -44,7 +47,7 @@
 //! #         Ok(false)
 //! #     }
 //! # }
-//! use embedded_hal_compat::ForwardCompat;
+//! use embedded_hal_compat::{Forward, ForwardCompat, markers::*};
 //!
 //! // Create e-h v0.2.x based type (mock)
 //! let mut old = OutputPin0_2;
@@ -52,7 +55,7 @@
 //! let _ = eh0_2::digital::v2::OutputPin::set_high(&mut old);
 //!
 //! // Apply forward compatibility wrapper
-//! let mut new = old.forward();
+//! let mut new: Forward<_, ForwardIoPin> = old.forward();
 //! // Access via e-h v1.x.x methods
 //! let _ = eh1_0::digital::OutputPin::set_high(&mut new);
 //!```
@@ -121,6 +124,7 @@ pub use eh0_2;
 pub use eh1_0;
 
 mod forward;
+pub mod markers;
 mod reverse;
 
 // Forward compatibility wrapper trait, access using `.forward()`

--- a/src/markers.rs
+++ b/src/markers.rs
@@ -1,0 +1,8 @@
+/// Marker for input only pins
+pub struct ForwardInputPin;
+
+/// Marker for output only pins
+pub struct ForwardOutputPin;
+
+/// Marker for input-output pins
+pub struct ForwardIoPin;

--- a/tests/digital_forward.rs
+++ b/tests/digital_forward.rs
@@ -83,7 +83,7 @@ fn io_pin_forward() {
 #[test]
 fn input_pin_forward() {
     let periph_0_2 = InputPin;
-    let mut periph_1_0 = periph_0_2.forward();
+    let periph_1_0 = periph_0_2.forward();
     assert!(eh1_0::digital::InputPin::is_high(&periph_1_0).unwrap());
 }
 

--- a/tests/digital_forward.rs
+++ b/tests/digital_forward.rs
@@ -1,20 +1,31 @@
-use embedded_hal_compat::ForwardCompat;
+use embedded_hal_compat::{markers::*, Forward, ForwardCompat};
 
 #[derive(Debug)]
-enum PinError {
+enum InputPinError {
     _Something,
 }
 
-impl eh1_0::digital::Error for PinError {
+impl eh1_0::digital::Error for InputPinError {
     fn kind(&self) -> eh1_0::digital::ErrorKind {
         eh1_0::digital::ErrorKind::Other
     }
 }
 
-struct Peripheral;
+#[derive(Debug)]
+enum OutputPinError {
+    _Something,
+}
 
-impl eh0_2::digital::v2::OutputPin for Peripheral {
-    type Error = PinError;
+impl eh1_0::digital::Error for OutputPinError {
+    fn kind(&self) -> eh1_0::digital::ErrorKind {
+        eh1_0::digital::ErrorKind::Other
+    }
+}
+
+struct IoPin;
+
+impl eh0_2::digital::v2::OutputPin for IoPin {
+    type Error = InputPinError;
 
     fn set_high(&mut self) -> Result<(), Self::Error> {
         Ok(())
@@ -24,8 +35,34 @@ impl eh0_2::digital::v2::OutputPin for Peripheral {
     }
 }
 
-impl eh0_2::digital::v2::InputPin for Peripheral {
-    type Error = PinError;
+impl eh0_2::digital::v2::InputPin for IoPin {
+    type Error = InputPinError;
+
+    fn is_high(&self) -> Result<bool, Self::Error> {
+        Ok(true)
+    }
+    fn is_low(&self) -> Result<bool, Self::Error> {
+        Ok(false)
+    }
+}
+
+struct OutputPin;
+
+impl eh0_2::digital::v2::OutputPin for OutputPin {
+    type Error = OutputPinError;
+
+    fn set_high(&mut self) -> Result<(), Self::Error> {
+        Ok(())
+    }
+    fn set_low(&mut self) -> Result<(), Self::Error> {
+        Ok(())
+    }
+}
+
+struct InputPin;
+
+impl eh0_2::digital::v2::InputPin for InputPin {
+    type Error = InputPinError;
 
     fn is_high(&self) -> Result<bool, Self::Error> {
         Ok(true)
@@ -36,9 +73,23 @@ impl eh0_2::digital::v2::InputPin for Peripheral {
 }
 
 #[test]
-fn can_forward() {
-    let periph_0_2 = Peripheral;
-    let mut periph_1_0 = periph_0_2.forward();
+fn io_pin_forward() {
+    let periph_0_2 = IoPin;
+    let mut periph_1_0: Forward<_, ForwardIoPin> = periph_0_2.forward();
     assert!(eh1_0::digital::OutputPin::set_high(&mut periph_1_0).is_ok());
     assert!(eh1_0::digital::InputPin::is_high(&periph_1_0).unwrap());
+}
+
+#[test]
+fn input_pin_forward() {
+    let periph_0_2 = InputPin;
+    let mut periph_1_0 = periph_0_2.forward();
+    assert!(eh1_0::digital::InputPin::is_high(&periph_1_0).unwrap());
+}
+
+#[test]
+fn output_pin_forward() {
+    let periph_0_2 = OutputPin;
+    let mut periph_1_0 = periph_0_2.forward();
+    assert!(eh1_0::digital::OutputPin::set_high(&mut periph_1_0).is_ok());
 }


### PR DESCRIPTION
the default type in the trait means this should continue to work without annotation for everything else, but allows gpio wrappers to be specified using the new marker types. there may be better ways (particularly if we had associated type defaults) but, this seems to be workable with the current resolver.

this _may_ cause breakage for some uses of `.forward()` on IO pins but, these were already mostly broken so seems okay to me.

resolves #24 (though may need to be backported to prior releases if folks are stuck on prior e-h alpha versions)