### PR TITLE
wip: Update to embedded-hal v1.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ features = [ "unproven" ]
 
 [dependencies.eh1_0]
 package = "embedded-hal"
-version = "=1.0.0-rc.1"
+version = "1.0.0"
 
 
 [package.metadata.docs.rs]
@@ -33,3 +33,6 @@ version = "=1.0.0-rc.1"
 # RUSTDOCFLAGS="--cfg docsrs" cargo +nightly doc --all-features --no-deps --open
 all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
+
+[patch.crates-io]
+embedded-hal = { git = "https://github.com/Dirbaio/embedded-hal", rev = "0e4a3fd08ab919a0b697368305cd3dd926319ed2"}

--- a/src/forward.rs
+++ b/src/forward.rs
@@ -88,12 +88,12 @@ mod digital {
         E: core::fmt::Debug,
     {
         /// Is the input pin high?
-        fn is_high(&self) -> Result<bool, Self::Error> {
+        fn is_high(&mut self) -> Result<bool, Self::Error> {
             self.inner.is_high().map_err(ForwardError)
         }
 
         /// Is the input pin low?
-        fn is_low(&self) -> Result<bool, Self::Error> {
+        fn is_low(&mut self) -> Result<bool, Self::Error> {
             self.inner.is_low().map_err(ForwardError)
         }
     }
@@ -136,12 +136,12 @@ mod digital {
         E: core::fmt::Debug,
     {
         /// Is the input pin high?
-        fn is_high(&self) -> Result<bool, Self::Error> {
+        fn is_high(&mut self) -> Result<bool, Self::Error> {
             self.inner.is_high().map_err(ForwardError)
         }
 
         /// Is the input pin low?
-        fn is_low(&self) -> Result<bool, Self::Error> {
+        fn is_low(&mut self) -> Result<bool, Self::Error> {
             self.inner.is_low().map_err(ForwardError)
         }
     }
@@ -167,10 +167,14 @@ mod digital {
 mod delay {
     use super::Forward;
 
-    impl<T> eh1_0::delay::DelayUs for Forward<T>
+    impl<T> eh1_0::delay::DelayNs for Forward<T>
     where
         T: eh0_2::blocking::delay::DelayUs<u32>,
     {
+        fn delay_ns(&mut self, ns: u32) {
+            self.inner.delay_us(ns.div_ceil(1000))
+        }
+
         fn delay_us(&mut self, us: u32) {
             self.inner.delay_us(us)
         }

--- a/src/reverse.rs
+++ b/src/reverse.rs
@@ -97,7 +97,7 @@ mod delay {
 
     impl<T> eh0_2::blocking::delay::DelayMs<u32> for Reverse<T>
     where
-        T: eh1_0::delay::DelayUs,
+        T: eh1_0::delay::DelayNs,
     {
         fn delay_ms(&mut self, ms: u32) {
             self.inner.delay_us(ms * 1000)
@@ -106,7 +106,7 @@ mod delay {
 
     impl<T> eh0_2::blocking::delay::DelayMs<u16> for Reverse<T>
     where
-        T: eh1_0::delay::DelayUs,
+        T: eh1_0::delay::DelayNs,
     {
         fn delay_ms(&mut self, ms: u16) {
             self.inner.delay_us(ms as u32 * 1000)
@@ -115,7 +115,7 @@ mod delay {
 
     impl<T> eh0_2::blocking::delay::DelayUs<u32> for Reverse<T>
     where
-        T: eh1_0::delay::DelayUs,
+        T: eh1_0::delay::DelayNs,
     {
         fn delay_us(&mut self, us: u32) {
             self.inner.delay_us(us)
@@ -124,7 +124,7 @@ mod delay {
 
     impl<T> eh0_2::blocking::delay::DelayUs<u16> for Reverse<T>
     where
-        T: eh1_0::delay::DelayUs,
+        T: eh1_0::delay::DelayNs,
     {
         fn delay_us(&mut self, us: u16) {
             self.inner.delay_us(us as u32)


### PR DESCRIPTION
I'm not sure how to handle `Reverse` for `InputPin`: the 0.2 traits only give us `&self`, but the 1.0 traits require `&mut self`.

Maybe we can not implement `InputPin` on `Reverse<T>`, and and add a second set of mpls on `Reverse<RefCell<T>>` which does impl `InputPin`?? 
