### PR TITLE
Update to embedded-hal 1.0.0

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -38,7 +38,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        rust: [stable, 1.62.0]
+        rust: [stable, 1.69.0]
         features: ["", "--all-features"]
         TARGET:
           - x86_64-unknown-linux-gnu

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -38,7 +38,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        rust: [stable, 1.69.0]
+        rust: [stable, 1.73.0]
         features: ["", "--all-features"]
         TARGET:
           - x86_64-unknown-linux-gnu

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ features = [ "unproven" ]
 
 [dependencies.eh1_0]
 package = "embedded-hal"
-version = "=1.0.0-rc.1"
+version = "1.0.0"
 
 
 [package.metadata.docs.rs]
@@ -33,3 +33,6 @@ version = "=1.0.0-rc.1"
 # RUSTDOCFLAGS="--cfg docsrs" cargo +nightly doc --all-features --no-deps --open
 all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
+
+[patch.crates-io]
+embedded-hal = { git = "https://github.com/Dirbaio/embedded-hal", rev = "0e4a3fd08ab919a0b697368305cd3dd926319ed2"}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,3 @@ version = "1.0.0"
 # RUSTDOCFLAGS="--cfg docsrs" cargo +nightly doc --all-features --no-deps --open
 all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
-
-[patch.crates-io]
-embedded-hal = { git = "https://github.com/Dirbaio/embedded-hal", rev = "0e4a3fd08ab919a0b697368305cd3dd926319ed2"}

--- a/src/forward.rs
+++ b/src/forward.rs
@@ -88,12 +88,12 @@ mod digital {
         E: core::fmt::Debug,
     {
         /// Is the input pin high?
-        fn is_high(&self) -> Result<bool, Self::Error> {
+        fn is_high(&mut self) -> Result<bool, Self::Error> {
             self.inner.is_high().map_err(ForwardError)
         }
 
         /// Is the input pin low?
-        fn is_low(&self) -> Result<bool, Self::Error> {
+        fn is_low(&mut self) -> Result<bool, Self::Error> {
             self.inner.is_low().map_err(ForwardError)
         }
     }
@@ -136,12 +136,12 @@ mod digital {
         E: core::fmt::Debug,
     {
         /// Is the input pin high?
-        fn is_high(&self) -> Result<bool, Self::Error> {
+        fn is_high(&mut self) -> Result<bool, Self::Error> {
             self.inner.is_high().map_err(ForwardError)
         }
 
         /// Is the input pin low?
-        fn is_low(&self) -> Result<bool, Self::Error> {
+        fn is_low(&mut self) -> Result<bool, Self::Error> {
             self.inner.is_low().map_err(ForwardError)
         }
     }
@@ -167,10 +167,14 @@ mod digital {
 mod delay {
     use super::Forward;
 
-    impl<T> eh1_0::delay::DelayUs for Forward<T>
+    impl<T> eh1_0::delay::DelayNs for Forward<T>
     where
         T: eh0_2::blocking::delay::DelayUs<u32>,
     {
+        fn delay_ns(&mut self, ns: u32) {
+            self.inner.delay_us(ns.div_ceil(1000))
+        }
+
         fn delay_us(&mut self, us: u32) {
             self.inner.delay_us(us)
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -66,6 +66,8 @@
 //! Calling `ReverseCompat::reverse()` (or `.reverse()`) on `v1.0.x` types creates a wrapper for
 //! use with `v0.2.x` consumers, so you can drop these wrapped types into drivers expecting
 //! `v0.2.x` types.
+//! 
+//! Note that input and output pins require `.reverse_cell()` as a workaround for mutability changes.
 //!
 //!```
 //! # use core::convert::Infallible;
@@ -94,11 +96,43 @@
 //! let _ = eh1_0::digital::OutputPin::set_high(&mut new);
 //!
 //! // Apply backwards compatibility wrapper
-//! let mut old = new.reverse();
+//! let mut old = new.reverse_cell();
 //! // Access via e-h v0.2.x methods
 //! let _ = eh0_2::digital::v2::OutputPin::set_high(&mut old);
 //!```
 //!
+//! ```
+//! # use core::convert::Infallible;
+//! # pub struct InputPin1_0;
+//! #
+//! # impl eh1_0::digital::ErrorType for InputPin1_0 {
+//! #     type Error = Infallible;
+//! # }
+//! #
+//! # impl eh1_0::digital::InputPin for InputPin1_0 {
+//! #     /// Set the output as high
+//! #     fn is_high(&mut self) -> Result<bool, Self::Error> {
+//! #         Ok(true)
+//! #     }
+//! #
+//! #     /// Set the output as low
+//! #     fn is_low(&mut self) -> Result<bool, Self::Error> {
+//! #         Ok(false)
+//! #     }
+//! # }
+//! use embedded_hal_compat::ReverseCompat;
+//!
+//! // Create e-h v1.x.x based type (mock)
+//! let mut new = InputPin1_0;
+//! // Access via e-h v1.x.x methods
+//! let _ = eh1_0::digital::InputPin::is_high(&mut new);
+//!
+//! // Apply backwards compatibility wrapper
+//! let mut old = new.reverse_cell();
+//! // Access via e-h v0.2.x methods
+//! let _ = eh0_2::digital::v2::InputPin::is_high(&mut old);
+//!```
+//! 
 //! ## Optional features
 //! ### `alloc`
 //! The `alloc` feature enables an implementation of the I2C and SPI `Transactional`

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -66,7 +66,7 @@
 //! Calling `ReverseCompat::reverse()` (or `.reverse()`) on `v1.0.x` types creates a wrapper for
 //! use with `v0.2.x` consumers, so you can drop these wrapped types into drivers expecting
 //! `v0.2.x` types.
-//! 
+//!
 //! Note that input and output pins require `.reverse_cell()` as a workaround for mutability changes.
 //!
 //!```
@@ -132,7 +132,7 @@
 //! // Access via e-h v0.2.x methods
 //! let _ = eh0_2::digital::v2::InputPin::is_high(&mut old);
 //!```
-//! 
+//!
 //! ## Optional features
 //! ### `alloc`
 //! The `alloc` feature enables an implementation of the I2C and SPI `Transactional`

--- a/src/reverse.rs
+++ b/src/reverse.rs
@@ -2,8 +2,8 @@
 //! A compatibility layer to alleviate (some) of the issues resolving from changes to embedded-hal
 // Copyright 2021 Ryan Kurte
 
-use core::fmt::Debug;
 use core::cell::RefCell;
+use core::fmt::Debug;
 
 /// Reverse compatibility container object.
 /// This is generic over different E-H types and will provide adaption
@@ -64,8 +64,8 @@ impl<T> Reverse<T> {
 
 // Digital / GPIOs
 mod digital {
-    use core::cell::RefCell;
     use super::{Debug, Reverse};
+    use core::cell::RefCell;
 
     impl<T, E> eh0_2::digital::v2::InputPin for Reverse<RefCell<T>>
     where

--- a/src/reverse.rs
+++ b/src/reverse.rs
@@ -97,7 +97,7 @@ mod delay {
 
     impl<T> eh0_2::blocking::delay::DelayMs<u32> for Reverse<T>
     where
-        T: eh1_0::delay::DelayUs,
+        T: eh1_0::delay::DelayNs,
     {
         fn delay_ms(&mut self, ms: u32) {
             self.inner.delay_us(ms * 1000)
@@ -106,7 +106,7 @@ mod delay {
 
     impl<T> eh0_2::blocking::delay::DelayMs<u16> for Reverse<T>
     where
-        T: eh1_0::delay::DelayUs,
+        T: eh1_0::delay::DelayNs,
     {
         fn delay_ms(&mut self, ms: u16) {
             self.inner.delay_us(ms as u32 * 1000)
@@ -115,7 +115,7 @@ mod delay {
 
     impl<T> eh0_2::blocking::delay::DelayUs<u32> for Reverse<T>
     where
-        T: eh1_0::delay::DelayUs,
+        T: eh1_0::delay::DelayNs,
     {
         fn delay_us(&mut self, us: u32) {
             self.inner.delay_us(us)
@@ -124,7 +124,7 @@ mod delay {
 
     impl<T> eh0_2::blocking::delay::DelayUs<u16> for Reverse<T>
     where
-        T: eh1_0::delay::DelayUs,
+        T: eh1_0::delay::DelayNs,
     {
         fn delay_us(&mut self, us: u16) {
             self.inner.delay_us(us as u32)

--- a/tests/delay_forward.rs
+++ b/tests/delay_forward.rs
@@ -14,6 +14,6 @@ impl eh0_2::blocking::delay::DelayUs<u32> for Peripheral {
 fn can_forward() {
     let periph_0_2 = Peripheral;
     let mut periph_1_0 = periph_0_2.forward();
-    eh1_0::delay::DelayUs::delay_ms(&mut periph_1_0, 0);
-    eh1_0::delay::DelayUs::delay_ms(&mut periph_1_0, 0);
+    eh1_0::delay::DelayNs::delay_ms(&mut periph_1_0, 0);
+    eh1_0::delay::DelayNs::delay_ms(&mut periph_1_0, 0);
 }

--- a/tests/delay_reverse.rs
+++ b/tests/delay_reverse.rs
@@ -2,9 +2,8 @@ use embedded_hal_compat::ReverseCompat;
 
 struct Peripheral;
 
-impl eh1_0::delay::DelayUs for Peripheral {
-    fn delay_us(&mut self, _us: u32) {}
-    fn delay_ms(&mut self, _ms: u32) {}
+impl eh1_0::delay::DelayNs for Peripheral {
+    fn delay_ns(&mut self, _ns: u32) {}
 }
 
 #[test]

--- a/tests/digital_forward.rs
+++ b/tests/digital_forward.rs
@@ -77,14 +77,14 @@ fn io_pin_forward() {
     let periph_0_2 = IoPin;
     let mut periph_1_0: Forward<_, ForwardIoPin> = periph_0_2.forward();
     assert!(eh1_0::digital::OutputPin::set_high(&mut periph_1_0).is_ok());
-    assert!(eh1_0::digital::InputPin::is_high(&periph_1_0).unwrap());
+    assert!(eh1_0::digital::InputPin::is_high(&mut periph_1_0).unwrap());
 }
 
 #[test]
 fn input_pin_forward() {
     let periph_0_2 = InputPin;
-    let periph_1_0 = periph_0_2.forward();
-    assert!(eh1_0::digital::InputPin::is_high(&periph_1_0).unwrap());
+    let mut periph_1_0 = periph_0_2.forward();
+    assert!(eh1_0::digital::InputPin::is_high(&mut periph_1_0).unwrap());
 }
 
 #[test]

--- a/tests/digital_reverse.rs
+++ b/tests/digital_reverse.rs
@@ -27,10 +27,10 @@ impl eh1_0::digital::OutputPin for Peripheral {
 }
 
 impl eh1_0::digital::InputPin for Peripheral {
-    fn is_high(&self) -> Result<bool, Self::Error> {
+    fn is_high(&mut self) -> Result<bool, Self::Error> {
         Ok(true)
     }
-    fn is_low(&self) -> Result<bool, Self::Error> {
+    fn is_low(&mut self) -> Result<bool, Self::Error> {
         Ok(false)
     }
 }
@@ -38,7 +38,7 @@ impl eh1_0::digital::InputPin for Peripheral {
 #[test]
 fn can_reverse() {
     let periph_1_0 = Peripheral;
-    let mut periph_0_2 = periph_1_0.reverse();
+    let mut periph_0_2 = periph_1_0.reverse_cell();
     assert!(eh0_2::digital::v2::OutputPin::set_high(&mut periph_0_2).is_ok());
     assert!(eh0_2::digital::v2::InputPin::is_high(&periph_0_2).unwrap());
 }


### PR DESCRIPTION
updates #32

- adds `.reverse_cell()` for `RefCell` wrapping
- swaps pin impls to use RefCells (you can't move only the `InputPin` impl without causing problems, seemed simpler to always do this than to have two possible paths)

cc. @dirbaio @MabezDev