### PR TITLE
Impl `embedded_hal_async::digital::Wait` for `Forward`

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: 1.73.0
+          toolchain: 1.75.0
           targets: x86_64-unknown-linux-gnu
           components: clippy
 
@@ -38,7 +38,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        rust: [stable, 1.73.0]
+        rust: [stable, 1.75.0]
         features: ["", "--all-features"]
         TARGET:
           - x86_64-unknown-linux-gnu

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Added `embedded-hal-async` v1.0.0 to dependencies.
 - Added `futures` v0.3.31 to dev-dependencies.
 - Added unit test for `Wait` trait forwarding.
+
+### Changed
 - Updated MSRV to 1.75.
 - Updated Rust edition to 2021.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+- Implimented `embedded-hal-async::digital::Wait` trait for all `Forward` variants,
+  which exposes the `wait_for_{rising,falling,any}_edge` and `wait_for_{low,high}` functions
+  on forwarded pins that also impliment `Wait`.
+- Added `embedded-hal-async` v1.0.0 to dependencies.
+- Added `futures` v0.3.31 to dev-dependencies.
+- Added unit test for `Wait` trait forwarding.
+- Updated MSRV to 1.75.
+- Updated Rust edition to 2021.
+
 ## [0.13.0] - 2024-05-04
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,8 +5,9 @@ repository = "https://github.com/ryankurte/embedded-hal-compat"
 keywords = [ "embedded", "embedded-hal", "no-std", "compat", "compatibility" ]
 version = "0.13.0"
 authors = ["Ryan Kurte <ryan@kurte.nz>", "Diego Barrios Romero <eldruin@gmail.com>"]
-edition = "2018"
+edition = "2021"
 license = "MIT"
+rust-version = "1.75"
 
 [features]
 alloc = ["embedded-io?/alloc"]
@@ -30,6 +31,9 @@ version = "1.0.0"
 [dependencies.eh1_0_async]
 package = "embedded-hal-async"
 version = "1.0.0"
+
+[dev-dependencies]
+futures = "0.3.31"
 
 [package.metadata.docs.rs]
 # To build locally:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,9 @@ features = [ "unproven" ]
 package = "embedded-hal"
 version = "1.0.0"
 
+[dependencies.eh1_0_async]
+package = "embedded-hal-async"
+version = "1.0.0"
 
 [package.metadata.docs.rs]
 # To build locally:

--- a/src/forward.rs
+++ b/src/forward.rs
@@ -98,6 +98,38 @@ mod digital {
         }
     }
 
+    impl<T, E> eh1_0_async::digital::Wait for Forward<T, ForwardInputPin>
+    where
+        T: eh0_2::digital::v2::InputPin<Error = E> + eh1_0_async::digital::Wait<Error = E>,
+        E: core::fmt::Debug,
+    {
+        async fn wait_for_high(&mut self) -> Result<(), Self::Error> {
+            self.inner.wait_for_high().await.map_err(ForwardError)
+        }
+
+        async fn wait_for_low(&mut self) -> Result<(), Self::Error> {
+            self.inner.wait_for_low().await.map_err(ForwardError)
+        }
+
+        async fn wait_for_rising_edge(&mut self) -> Result<(), Self::Error> {
+            self.inner
+                .wait_for_rising_edge()
+                .await
+                .map_err(ForwardError)
+        }
+
+        async fn wait_for_falling_edge(&mut self) -> Result<(), Self::Error> {
+            self.inner
+                .wait_for_falling_edge()
+                .await
+                .map_err(ForwardError)
+        }
+
+        async fn wait_for_any_edge(&mut self) -> Result<(), Self::Error> {
+            self.inner.wait_for_any_edge().await.map_err(ForwardError)
+        }
+    }
+
     impl<T, E> eh1_0::digital::ErrorType for Forward<T, ForwardOutputPin>
     where
         T: eh0_2::digital::v2::OutputPin<Error = E>,
@@ -119,6 +151,38 @@ mod digital {
         /// Set the output as low
         fn set_low(&mut self) -> Result<(), Self::Error> {
             self.inner.set_low().map_err(ForwardError)
+        }
+    }
+
+    impl<T, E> eh1_0_async::digital::Wait for Forward<T, ForwardOutputPin>
+    where
+        T: eh0_2::digital::v2::OutputPin<Error = E> + eh1_0_async::digital::Wait<Error = E>,
+        E: core::fmt::Debug,
+    {
+        async fn wait_for_high(&mut self) -> Result<(), Self::Error> {
+            self.inner.wait_for_high().await.map_err(ForwardError)
+        }
+
+        async fn wait_for_low(&mut self) -> Result<(), Self::Error> {
+            self.inner.wait_for_low().await.map_err(ForwardError)
+        }
+
+        async fn wait_for_rising_edge(&mut self) -> Result<(), Self::Error> {
+            self.inner
+                .wait_for_rising_edge()
+                .await
+                .map_err(ForwardError)
+        }
+
+        async fn wait_for_falling_edge(&mut self) -> Result<(), Self::Error> {
+            self.inner
+                .wait_for_falling_edge()
+                .await
+                .map_err(ForwardError)
+        }
+
+        async fn wait_for_any_edge(&mut self) -> Result<(), Self::Error> {
+            self.inner.wait_for_any_edge().await.map_err(ForwardError)
         }
     }
 
@@ -159,6 +223,40 @@ mod digital {
         /// Set the output as low
         fn set_low(&mut self) -> Result<(), Self::Error> {
             self.inner.set_low().map_err(ForwardError)
+        }
+    }
+
+    impl<T, E> eh1_0_async::digital::Wait for Forward<T, ForwardIoPin>
+    where
+        T: eh0_2::digital::v2::InputPin<Error = E>
+            + eh0_2::digital::v2::OutputPin<Error = E>
+            + eh1_0_async::digital::Wait<Error = E>,
+        E: core::fmt::Debug,
+    {
+        async fn wait_for_high(&mut self) -> Result<(), Self::Error> {
+            self.inner.wait_for_high().await.map_err(ForwardError)
+        }
+
+        async fn wait_for_low(&mut self) -> Result<(), Self::Error> {
+            self.inner.wait_for_low().await.map_err(ForwardError)
+        }
+
+        async fn wait_for_rising_edge(&mut self) -> Result<(), Self::Error> {
+            self.inner
+                .wait_for_rising_edge()
+                .await
+                .map_err(ForwardError)
+        }
+
+        async fn wait_for_falling_edge(&mut self) -> Result<(), Self::Error> {
+            self.inner
+                .wait_for_falling_edge()
+                .await
+                .map_err(ForwardError)
+        }
+
+        async fn wait_for_any_edge(&mut self) -> Result<(), Self::Error> {
+            self.inner.wait_for_any_edge().await.map_err(ForwardError)
         }
     }
 }

--- a/tests/wait_forward.rs
+++ b/tests/wait_forward.rs
@@ -1,0 +1,64 @@
+use embedded_hal_compat::ForwardCompat;
+use futures::executor::block_on;
+
+#[derive(Debug)]
+enum InputPinError {
+    _Something,
+}
+
+impl eh1_0::digital::Error for InputPinError {
+    fn kind(&self) -> eh1_0::digital::ErrorKind {
+        eh1_0::digital::ErrorKind::Other
+    }
+}
+
+// An InputPin from embedded-hal 0.2, with a Wait implementation from embedded-hal 1.0 on it.
+struct InputPin;
+
+impl eh0_2::digital::v2::InputPin for InputPin {
+    type Error = InputPinError;
+
+    fn is_high(&self) -> Result<bool, Self::Error> {
+        Ok(true)
+    }
+    fn is_low(&self) -> Result<bool, Self::Error> {
+        Ok(false)
+    }
+}
+
+impl eh1_0::digital::ErrorType for InputPin {
+    type Error = InputPinError;
+}
+
+impl eh1_0_async::digital::Wait for InputPin {
+    async fn wait_for_high(&mut self) -> Result<(), Self::Error> {
+        Ok(())
+    }
+
+    async fn wait_for_low(&mut self) -> Result<(), Self::Error> {
+        Ok(())
+    }
+
+    async fn wait_for_rising_edge(&mut self) -> Result<(), Self::Error> {
+        Ok(())
+    }
+
+    async fn wait_for_falling_edge(&mut self) -> Result<(), Self::Error> {
+        Ok(())
+    }
+
+    async fn wait_for_any_edge(&mut self) -> Result<(), Self::Error> {
+        Ok(())
+    }
+}
+
+#[test]
+fn input_pin_forward() {
+    let periph_0_2 = InputPin;
+    let mut periph_1_0 = periph_0_2.forward();
+    assert!(eh1_0::digital::InputPin::is_high(&mut periph_1_0).unwrap());
+    assert!(block_on(async {
+        eh1_0_async::digital::Wait::wait_for_any_edge(&mut periph_1_0).await
+    })
+    .is_ok());
+}


### PR DESCRIPTION
This is useful with crates like `atsamd-hal`, that use a lot of old/new embedded-hal traits interchangeably. 