### PR TITLE
Simplify I2c constraints for Forward direction

### DIFF
--- a/src/forward.rs
+++ b/src/forward.rs
@@ -358,11 +358,8 @@ mod i2c {
     impl<T, E> eh1_0::i2c::I2c<SevenBitAddress> for Forward<T>
     where
         T: eh0_2_i2c::Write<Error = E>
-            + eh0_2_i2c::WriteIter<Error = E>
             + eh0_2_i2c::Read<Error = E>
             + eh0_2_i2c::WriteRead<Error = E>
-            + eh0_2_i2c::WriteIterRead<Error = E>
-            + eh0_2_i2c::Transactional<Error = E>
             + eh0_2_i2c::TransactionalIter<Error = E>,
         E: core::fmt::Debug,
     {


### PR DESCRIPTION
The forward implemenation does not use all the traits it requires. This makes it complicated to forward convert implementations that are simpler and do not provide all the methods.